### PR TITLE
Lts 13 0

### DIFF
--- a/src/Web/WebPush.hs
+++ b/src/Web/WebPush.hs
@@ -233,3 +233,4 @@ data PushNotificationError = EndpointParseFailed SomeException
                            | MessageEncryptionFailed CryptoError
                            | RecepientEndpointNotFound
                            | PushRequestFailed SomeException
+                            deriving (Show)

--- a/src/Web/WebPush.hs
+++ b/src/Web/WebPush.hs
@@ -124,12 +124,12 @@ sendPushNotification vapidKeys httpManager pushNotification = do
         Left exc@(SomeException _) -> return $ Left $ EndpointParseFailed exc
         Right initReq -> do
             time <- liftIO $ getCurrentTime
-            eitherJwt <- webPushJWT vapidKeys $ VAPIDClaims { vapidAud =  JWT.Audience [ fromString $ T.unpack $ TE.decodeUtf8With TE.lenientDecode $
+            eitherJwt <- webPushJWT vapidKeys (VAPIDClaims { vapidAud =  JWT.Audience [ fromString $ T.unpack $ TE.decodeUtf8With TE.lenientDecode $
                                                                                              BS.append (if secure initReq then "https://" else "http://") (host initReq)
                                                                                        ]
                                                             , vapidSub = fromString $ T.unpack $ T.append "mailto:" $ senderEmail pushNotification
                                                             , vapidExp = NumericDate $ addUTCTime 3000 time
-                                                            }
+                                                            }) initReq (T.unpack $ senderEmail pushNotification)
             case eitherJwt of
                 Left err -> return $ Left $ JWTGenerationFailed err
                 Right jwt -> do

--- a/src/Web/WebPush.hs
+++ b/src/Web/WebPush.hs
@@ -223,7 +223,7 @@ data PushNotificationDetails = PushNotificationDetails { endpoint :: Text
 data VAPIDKeysMinDetails = VAPIDKeysMinDetails { privateNumber :: Integer
                                                , publicCoordX :: Integer
                                                , publicCoordY :: Integer
-                                               }
+                                               } deriving (Show)
 
 -- |'RecepientEndpointNotFound' comes up when the endpoint is no longer recognized by the push service.
 -- This may happen if the user has cancelled the push subscription, and hence deleted the endpoint.

--- a/src/Web/WebPush.hs
+++ b/src/Web/WebPush.hs
@@ -143,7 +143,7 @@ sendPushNotification vapidKeys httpManager pushNotification = do
                         subscriptionPublicKeyBytes = B64.URL.decodeLenient $ TE.encodeUtf8 $ p256dh pushNotification
                         -- encode the message to a safe representation like base64URL before sending it to encryption algorithms
                         -- decode the message through service workers on browsers before trying to read the JSON
-                        plainMessage64Encoded = B64.URL.Lazy.encode $ A.encode $ A.toJSON $ message pushNotification
+                        plainMessage64Encoded = A.encode $ A.toJSON $ message pushNotification
 
                         eitherEncryptionOutput = webPushEncrypt $ EncryptionInput { applicationServerPrivateKey = ecdhServerPrivateKey
                                                                                   , userAgentPublicKeyBytes = subscriptionPublicKeyBytes

--- a/src/Web/WebPush.hs
+++ b/src/Web/WebPush.hs
@@ -191,7 +191,9 @@ sendPushNotification vapidKeys httpManager pushNotification = do
                                         -- when the endpoint is invalid, we need to remove it from database
                                         |(statusCode (responseStatus resp) == 404) -> return $ Left RecepientEndpointNotFound
                                     _ -> return $ Left $ PushRequestFailed err
-                                Right _ -> return $ Right ()
+                                Right resp -> do
+                                    liftIO $ print resp
+                                    return $ Right ()
 
     where
 

--- a/src/Web/WebPush/Internal.hs
+++ b/src/Web/WebPush/Internal.hs
@@ -26,7 +26,7 @@ import Crypto.JOSE.JWS                                         (newJWSHeader, Al
 import qualified Crypto.JOSE.Compact             as JOSE.Compact
 import qualified Crypto.JOSE.Error               as JOSE.Error
 
-import Data.Aeson                                              (ToJSON, toJSON, (.=), decode)
+import Data.Aeson                                              (ToJSON, toJSON, (.=), decode, eitherDecode)
 import qualified Data.Aeson                      as A
 import qualified Data.ByteString.Base64.URL      as B64.URL
 
@@ -56,7 +56,9 @@ webPushJWT vapidKeys vapidClaims = do
         privateKeyNumber = ECDSA.private_d $ ECDSA.toPrivateKey vapidKeys
         materialJsonTempl = "{\"kty\": \"EC\", \"crv\": \"P-256\", \"x\": %d, \"y\": %d, \"d\": %d}"
         materialJson = (printf materialJsonTempl publicKeyX publicKeyY privateKeyNumber) :: String
-        keyMaterial = fromJust $ decode (C.pack materialJson)
+    liftIO $ print materialJsonTempl
+    liftIO $ print (eitherDecode (C.pack materialJson) :: Either String JWK.KeyMaterial)
+    let keyMaterial = fromJust $ decode (C.pack materialJson)
     liftIO $ runExceptT $ do
         jwtData <- signClaims (JWK.fromKeyMaterial keyMaterial)
                               (newJWSHeader ((), ES256))

--- a/src/Web/WebPush/Internal.hs
+++ b/src/Web/WebPush/Internal.hs
@@ -27,7 +27,7 @@ import qualified Crypto.JOSE.Compact             as JOSE.Compact
 import qualified Crypto.JOSE.Error               as JOSE.Error
 import qualified Crypto.JOSE.Types               as JOSE
 
-import Data.Aeson                                              (ToJSON, toJSON, (.=), decode, eitherDecode)
+import Data.Aeson                                              (ToJSON, toJSON, (.=), decode, eitherDecode, encode)
 import qualified Data.Aeson                      as A
 import qualified Data.ByteString.Base64.URL      as B64.URL
 
@@ -57,9 +57,9 @@ webPushJWT vapidKeys vapidClaims = do
         privateKeyNumber = ECDSA.private_d $ ECDSA.toPrivateKey vapidKeys
         ecX = JOSE.SizedBase64Integer 32 $ publicKeyX
         ecY = JOSE.SizedBase64Integer 32 $ publicKeyY
-        ecD = Just $ JOSE.SizedBase64Integer 32 $ privateKeyNumber
+        ecD = JOSE.SizedBase64Integer 32 $ privateKeyNumber
         materialJsonTempl = "{\"kty\": \"EC\", \"crv\": \"P-256\", \"x\": \"%s\", \"y\": \"%s\", \"d\": \"%s\"}"
-        materialJson = (printf materialJsonTempl (show ecX) (show ecY) (show ecD)) :: String
+        materialJson = (printf materialJsonTempl (C.unpack $ encode ecX) (C.unpack $ encode ecY) (C.unpack $ encode ecD)) :: String
     liftIO $ print materialJson
     liftIO $ print (eitherDecode (C.pack materialJson) :: Either String JWK.KeyMaterial)
     let keyMaterial = fromJust $ decode (C.pack materialJson)

--- a/src/Web/WebPush/Internal.hs
+++ b/src/Web/WebPush/Internal.hs
@@ -12,23 +12,15 @@ import Data.Time.Format
 import Data.Time
 import qualified Crypto.PubKey.ECC.Types         as ECC
 import qualified Crypto.PubKey.ECC.ECDSA         as ECDSA
-import Crypto.Hash.Algorithms                                  (SHA256(..))
 import qualified Crypto.PubKey.ECC.DH            as ECDH
 import qualified Crypto.MAC.HMAC                 as HMAC
-import Crypto.Cipher.AES                                       (AES128)
 import qualified Crypto.Cipher.Types             as Cipher
+import Crypto.Hash.Algorithms                                  (SHA256(..))
+import Crypto.Cipher.AES                                       (AES128)
 import Crypto.Error                                            (CryptoFailable(CryptoPassed,CryptoFailed), CryptoError)
 import Network.HTTP.Client                                     (Request, host, secure)
 
--- import Crypto.JWT                                              (signClaims, emptyClaimsSet, claimSub, claimAud, claimExp)
--- import qualified Crypto.JWT                      as JWT
--- import qualified Crypto.JOSE.JWK                 as JWK
--- import Crypto.JOSE.JWS                                         (newJWSHeader, Alg(ES256))
--- import qualified Crypto.JOSE.Compact             as JOSE.Compact
--- import qualified Crypto.JOSE.Error               as JOSE.Error
--- import qualified Crypto.JOSE.Types               as JOSE
-
-import Data.Aeson                                              (ToJSON, toJSON, (.=))
+import Data.Aeson                                              ((.=))
 import qualified Data.Aeson                      as A
 import qualified Data.ByteString.Base64.URL      as B64.URL
 
@@ -81,26 +73,7 @@ webPushJWT vapidKeys initReq senderEmail = do
 
     let res = messageForJWTSignature <> "." <> encodedJWTSignature
     pure . Right . LB.fromStrict $ res
-            
-            ----------------------------
 
-
-
-data PushNotificationMessage = PushNotificationMessage { title :: Text
-                                                       , body :: Text
-                                                       , icon :: Text
-                                                       , url :: Text
-                                                       , tag :: Text
-                                                       }
-
-instance ToJSON PushNotificationMessage where
-   toJSON PushNotificationMessage {..} = A.object
-       [ "title" .= title
-       , "body" .= body
-       , "icon" .= icon
-       , "url" .= url
-       , "tag" .= tag
-       ]
 
 -- All inputs are in raw bytes with no encoding
 -- except for the plaintext for which raw bytes are the Base 64 encoded bytes

--- a/src/Web/WebPush/Internal.hs
+++ b/src/Web/WebPush/Internal.hs
@@ -54,7 +54,7 @@ webPushJWT :: MonadIO m => VAPIDKeys -> VAPIDClaims -> m (Either JOSE.Error.Erro
 webPushJWT vapidKeys vapidClaims = do
     let ECC.Point publicKeyX publicKeyY = ECDSA.public_q $ ECDSA.toPublicKey vapidKeys
         privateKeyNumber = ECDSA.private_d $ ECDSA.toPrivateKey vapidKeys
-        materialJsonTempl = "{\"kty\": \"EC\", \"crv\": \"P_256\", \"x\": %d, \"y\": %d, \"d\": %d}"
+        materialJsonTempl = "{\"kty\": \"EC\", \"crv\": \"P-256\", \"x\": %d, \"y\": %d, \"d\": %d}"
         materialJson = (printf materialJsonTempl publicKeyX publicKeyY privateKeyNumber) :: String
         keyMaterial = fromJust $ decode (C.pack materialJson)
     liftIO $ runExceptT $ do

--- a/src/Web/WebPush/Internal.hs
+++ b/src/Web/WebPush/Internal.hs
@@ -58,7 +58,7 @@ webPushJWT vapidKeys vapidClaims = do
         ecX = JOSE.SizedBase64Integer 32 $ publicKeyX
         ecY = JOSE.SizedBase64Integer 32 $ publicKeyY
         ecD = JOSE.SizedBase64Integer 32 $ privateKeyNumber
-        materialJsonTempl = "{\"kty\": \"EC\", \"crv\": \"P-256\", \"x\": \"%s\", \"y\": \"%s\", \"d\": \"%s\"}"
+        materialJsonTempl = "{\"kty\": \"EC\", \"crv\": \"P-256\", \"x\": %s, \"y\": %s, \"d\": %s}"
         materialJson = (printf materialJsonTempl (C.unpack $ encode ecX) (C.unpack $ encode ecY) (C.unpack $ encode ecD)) :: String
     liftIO $ print materialJson
     liftIO $ print (eitherDecode (C.pack materialJson) :: Either String JWK.KeyMaterial)

--- a/src/Web/WebPush/Internal.hs
+++ b/src/Web/WebPush/Internal.hs
@@ -40,7 +40,7 @@ type VAPIDKeys = ECDSA.KeyPair
 -- Manual implementation without using the JWT libraries.
 -- This works as well.
 -- Kept here mainly as process explanation.
-webPushJWT :: MonadIO m => VAPIDKeys -> Request -> T.Text -> m (Either a LB.ByteString)
+webPushJWT :: MonadIO m => VAPIDKeys -> Request -> T.Text -> m LB.ByteString
 webPushJWT vapidKeys initReq senderEmail = do
     -- JWT base 64 encoding is without padding
     time <- liftIO getCurrentTime
@@ -72,7 +72,7 @@ webPushJWT vapidKeys initReq senderEmail = do
                         (Binary.encode $ int32Bytes signS)
 
     let res = messageForJWTSignature <> "." <> encodedJWTSignature
-    pure . Right . LB.fromStrict $ res
+    pure . LB.fromStrict $ res
 
 
 -- All inputs are in raw bytes with no encoding

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-10.5
+resolver: lts-13.0
 
 packages:
 - '.'

--- a/web-push.cabal
+++ b/web-push.cabal
@@ -33,7 +33,6 @@ library
                      , exceptions                    >= 0.8.3      && <= 0.10.0
                      , transformers                  >= 0.5.2.0    && < 0.6
                      , mtl                           >= 2.2.1      && < 2.3
-                     , jose                          >= 0.6.0.3    && <= 0.8.0.0
                      , lens                          >= 4.15.1     && <= 4.17
 
   default-language:    Haskell2010

--- a/web-push.cabal
+++ b/web-push.cabal
@@ -24,17 +24,17 @@ library
                      , bytestring                    >= 0.9        && < 0.11
                      , base64-bytestring             >= 1.0.0.1    && < 1.1
                      , text                          >= 0.11       && < 2.0
-                     , cryptonite                    >= 0.24       && < 0.25
+                     , cryptonite                    >= 0.24       && <= 0.25
                      , binary                        >= 0.7.5      && < 0.9
                      , memory                        >= 0.14.5     && < 0.15
                      , random                        >= 1.1        && < 1.2
                      , http-client                   >= 0.5.7      && < 0.6
                      , http-types                    >= 0.8.6      && < 1.0
-                     , exceptions                    >= 0.8.3      && < 0.9
+                     , exceptions                    >= 0.8.3      && <= 0.10.0
                      , transformers                  >= 0.5.2.0    && < 0.6
                      , mtl                           >= 2.2.1      && < 2.3
-                     , jose                          >= 0.6.0.3    && < 0.7
-                     , lens                          >= 4.15.1     && < 4.16
+                     , jose                          >= 0.6.0.3    && <= 0.8.0.0
+                     , lens                          >= 4.15.1     && <= 4.17
 
   default-language:    Haskell2010
 
@@ -46,7 +46,7 @@ test-suite web-push-test
   ghc-options:         -Wall
   build-depends:       base
                      , web-push
-                     , hspec                         >= 2.4.3      && < 2.5
+                     , hspec                         >= 2.4.3      && <= 2.6.0
                      , bytestring                    >= 0.9        && < 0.11
                      , base64-bytestring             >= 1.0.0.1    && < 1.1
                      , binary                        >= 0.7.5      && < 0.9


### PR DESCRIPTION
Upgraded to lts 13.0
JOSE Lib encryption does not generate valid token payloads, so switched to manual implementation
Also JOSE closed some constructors, so that makes using more complicated

Refactored signatures according manual webpush sending implementation
Refactored sendWebPush function to exceptT